### PR TITLE
cq_package rescue mode

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,8 +17,7 @@ platforms:
 <%   chef_versions.each do |chef_version| %>
   - name: <%= p %>-chef-<%= chef_version %>
     driver_config:
-      box: opscode-<%= p %>
-      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_<%= p %>_chef-provisionerless.box
+      box: bento/<%= p %>
       require_chef_omnibus: <%= chef_version %>
     attributes:
       cq:

--- a/README.md
+++ b/README.md
@@ -198,7 +198,20 @@ explanation can be found below.
     <td><tt>recursive_install</tt></td>
     <td>Boolean</td>
     <td>Whether to use recursive flag when installing packages (required for
-    service packs and some hotfixes). Applies only to install action</td>
+    service packs and some hotfixes). Applies only to install and deploy
+    actions</td>
+  </tr>
+  <tr>
+    <td><tt>rescue_mode</tt></td>
+    <td>Boolean</td>
+    <td>Some packages may cause shutdown of entire OSGi because of
+    dependecy (i.e. cycle) or bundle priority issues. In such case after
+    package installation java process is still running, however the instance
+    is not responding over HTTP. After CQ/AEM restart everyting works
+    perfectly fine again.
+    This flag allows Chef to continue processing if it is not able to get OSGi
+    bundles state 6 times in a row. Applies only to install and deploy
+    actions</td>
   </tr>
   <tr>
     <td><tt>checksum</tt></td>

--- a/README.md
+++ b/README.md
@@ -385,8 +385,7 @@ keep checking OSGi bundles to detect their stable state, but none of these
 attempts will end successfully, as nothing is reachable over HTTP. After 30
 requests Chef run will be aborted. If `rescue_mode` was activated (set to
 `true`) then after 6 unsuccessful attempts an error will be printed and the
-processing will be continued (restart will be triggered on `cq60-author`
-service in this case).
+processing will be continued (restart of `cq60-author` service in this case).
 
 7th & 8th `cq_package` resources explain how to deal with AEM instance
 restarts after package installation.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ explanation can be found below.
   <tr>
     <td><tt>rescue_mode</tt></td>
     <td>Boolean</td>
-    <td>Some packages may cause shutdown of entire OSGi because of
+    <td>Some packages may cause shutdown of the entire OSGi because of
     dependecy (i.e. cycle) or bundle priority issues. In such case after
     package installation java process is still running, however the instance
     is not responding over HTTP. After CQ/AEM restart everyting works

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -546,7 +546,7 @@ def osgi_stability_healthcheck
   same_state_counter = 0
 
   # Number of iterations
-  i_max = 120
+  i_max = 30
 
   (1..i_max).each do |i|
     cmd = Mixlib::ShellOut.new(cmd_str, :timeout => 180)

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -572,8 +572,8 @@ def osgi_stability_healthcheck
 
       # Move on if the same state occurred N times in a row
       break if same_state_counter == 3
-    rescue => e
-      Chef::Log.warn("Unable to get OSGi bundles state: #{e}. Retrying...")
+    rescue
+      Chef::Log.warn('Unable to get OSGi bundles state. Retrying...')
 
       # Let's start over in case of an error (clear indicator of flapping OSGi
       # bundles)

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -33,6 +33,8 @@ attribute :http_pass,         :kind_of => String, :required => false,
                               :default => ''
 attribute :recursive_install, :kind_of => [TrueClass, FalseClass],
                               :required => false, :default => false
+attribute :rescue_mode,       :kind_of => [TrueClass, FalseClass],
+                              :required => false, :default => false
 attribute :checksum,          :kind_of => String, :required => false,
                               :default => ''
 


### PR DESCRIPTION
New `cq_package` resource property was added (`rescue_mode`) to handle situations with serious OSGi issues after CRX package installation.

Thanks to this attribute it is possible to continue processing despite of the fact that package installation caused shutdown of the entire OSGi (AEM is no longer responding over HTTP, but java process is still running).
