### PR TITLE
OSGi stability check improvment after package installation

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -571,7 +571,7 @@ def osgi_stability_healthcheck
       previous_state = cmd.stdout
 
       # Move on if the same state occurred N times in a row
-      break if same_state_counter == 3
+      break if same_state_counter == 6
     rescue
       Chef::Log.warn('Unable to get OSGi bundles state. Retrying...')
 


### PR DESCRIPTION
It turned out that unchanged state that occurred 3 times in a row (check every 10s) wasn't enough for AEM6 SP3 package deployed on clean AEM 6.0 instance. Currently to move on the same state has to persist for a minute (6 checks in a row).