### PR TITLE
Sling version that comes with AEM 6.1 no longer accepts DELETE method

### DIFF
--- a/libraries/provider_cq_jcr.rb
+++ b/libraries/provider_cq_jcr.rb
@@ -77,11 +77,16 @@ class Chef
       end
 
       def delete_node
-        http_resp = http_delete(
+        payload = {
+          ':operation' => 'delete'
+        }
+
+        http_resp = http_multipart_post(
           new_resource.instance,
           new_resource.path,
           new_resource.username,
-          new_resource.password
+          new_resource.password,
+          payload
         )
 
         http_response_validator(http_resp)


### PR DESCRIPTION
Just found out that `delete` action on `cq_jcr` causes the following error on AEM 6.1:

```
FATAL: Something went wrong during operation on /etc/replication/agents.publish/flush
HTTP response code: 405
HTTP response body: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html>
   <head><title>405 Method DELETE not supported</title></head>
   <body>
<h1>Method DELETE not supported</h1>
<p>Cannot serve request to /etc/replication/agents.publish/flush on this server</p>



<hr>
<address>ApacheSling/2.4 (jetty/9.2.9.v20150224, Java HotSpot(TM) 64-Bit Server VM 1.8.0_66, Linux 2.6.32-573.el6.x86_64 amd64)</address>
   </body>
</html>
```

The reason is that `DELETE` HTTP method was used so far and it worked quite well, but something has changed in AEM 6.1 Sling. Right now to delete JCR node `POST` request with appropriate payload has to be sent. Here are all the details: https://sling.apache.org/documentation/the-sling-engine/sling-api-crud-support.html#delete-a-resource