### PR TITLE
Custom resources fail if admin password contains special characters

### DIFF
--- a/providers/osgi_config.rb
+++ b/providers/osgi_config.rb
@@ -27,8 +27,8 @@ end
 def osgi_config_list
   cmd_str = "#{node['cq-unix-toolkit']['install_dir']}/cqcfgls "\
             "-i #{new_resource.instance} "\
-            "-u #{new_resource.username} "\
-            "-p #{new_resource.password} "
+            "-u '#{new_resource.username}' "\
+            "-p '#{new_resource.password}' "
 
   cmd = Mixlib::ShellOut.new(cmd_str)
   cmd.run_command
@@ -198,8 +198,8 @@ end
 def raw_config_info(name)
   cmd_str = "#{node['cq-unix-toolkit']['install_dir']}/cqcfg "\
             "-i #{new_resource.instance} "\
-            "-u #{new_resource.username} "\
-            "-p #{new_resource.password} "\
+            "-u '#{new_resource.username}' "\
+            "-p '#{new_resource.password}' "\
             '-j ' +
             name
 
@@ -377,8 +377,8 @@ def create_osgi_config(factory_flag = false)
   cmd_str_base = "#{node['cq-unix-toolkit']['install_dir']}/cqcfg " +
                  cqcfg_params +
                  "-i #{new_resource.instance} "\
-                 "-u #{new_resource.username} "\
-                 "-p #{new_resource.password} "
+                 "-u '#{new_resource.username}' "\
+                 "-p '#{new_resource.password}' "
 
   if factory_flag
     cmd_str = cmd_str_base + "-f #{new_resource.factory_pid}"
@@ -400,8 +400,8 @@ end
 def delete_osgi_config
   cmd_str = "#{node['cq-unix-toolkit']['install_dir']}/cqcfgdel " +
             "-i #{new_resource.instance} "\
-            "-u #{new_resource.username} "\
-            "-p #{new_resource.password} " +
+            "-u '#{new_resource.username}' "\
+            "-p '#{new_resource.password}' " +
             @current_resource.pid
 
   cmd = Mixlib::ShellOut.new(cmd_str)

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -175,8 +175,8 @@ def package_list
     # Get list of packages using CQ UNIX Toolkit
     cmd_str = "#{node['cq-unix-toolkit']['install_dir']}/cqls -x "\
               "-i #{new_resource.instance} "\
-              "-u #{new_resource.username} "\
-              "-p #{new_resource.password}"
+              "-u '#{new_resource.username}' "\
+              "-p '#{new_resource.password}'"
     Chef::Log.debug('Listing packages present in CRX Package Manager')
     cmd = Mixlib::ShellOut.new(cmd_str, :timeout => 180)
     cmd.run_command
@@ -428,7 +428,7 @@ end
 # 1st requirement - CQ works fine
 def instance_healthcheck
   cmd_str = "curl -s -o /dev/null -w '%{http_code}' "\
-            "-u #{new_resource.username}:#{new_resource.password} "\
+            "-u '#{new_resource.username}':'#{new_resource.password}' "\
             "#{new_resource.instance}#{node['cq']['healthcheck_resource']}"
 
   Chef::Log.info('Verifying general instance state before proceeding with '\
@@ -463,8 +463,8 @@ end
 def pkg_mgr_bundle_healthcheck
   cmd_str = "#{node['cq-unix-toolkit']['install_dir']}/cqosgi -m "\
             "-i #{new_resource.instance} "\
-            "-u #{new_resource.username} "\
-            "-p #{new_resource.password} "\
+            "-u '#{new_resource.username}' "\
+            "-p '#{new_resource.password}' "\
             "| grep 'com.adobe.granite.crx-packagemgr' "\
             "| awk '{printf \"%s\", $3}'"
 
@@ -503,7 +503,7 @@ end
 # 3rd requirement: package listing using API works correctly
 def pkg_mgr_api_healthcheck
   cmd_str = "curl -s -o /dev/null -w '%{http_code}' "\
-            "-u #{new_resource.username}:#{new_resource.password} "\
+            "-u '#{new_resource.username}':'#{new_resource.password}' "\
             "#{new_resource.instance}/crx/packmgr/service.jsp -F cmd=ls"
 
   Chef::Log.info('Verifying CRX Package Manager API status code')
@@ -534,8 +534,8 @@ end
 # Detect changes in bundle state. X seconds without changes is considered as a
 # "safe" state.
 def osgi_stability_healthcheck
-  cmd_str = "curl -s -u #{new_resource.username}:#{new_resource.password} "\
-            "#{new_resource.instance}/system/console/bundles/.json"
+  cmd_str = "curl -s -u '#{new_resource.username}':'#{new_resource.password}'"\
+            " #{new_resource.instance}/system/console/bundles/.json"
 
   Chef::Log.info('Waiting for stable state of OSGi bundles...')
 
@@ -650,8 +650,8 @@ end
 def upload_package
   cmd_str = "#{node['cq-unix-toolkit']['install_dir']}/cqput "\
             "-i #{new_resource.instance} "\
-            "-u #{new_resource.username} "\
-            "-p #{new_resource.password} " +
+            "-u '#{new_resource.username}' "\
+            "-p '#{new_resource.password}' " +
             package_path
   cmd = Mixlib::ShellOut.new(cmd_str, :timeout => 600)
   Chef::Log.info "Uploading package #{new_resource.name}"
@@ -684,7 +684,7 @@ def install_package
   require 'json'
 
   cmd_str = "curl -s -X POST -w ';%{http_code}' "\
-            "-u #{new_resource.username}:#{new_resource.password} "\
+            "-u '#{new_resource.username}':'#{new_resource.password}' "\
             "#{new_resource.instance}/crx/packmgr/service/.json/etc/packages"
 
   # Empty group fix
@@ -753,7 +753,7 @@ def uninstall_package
   require 'json'
 
   cmd_str = "curl -s -X POST -w ';%{http_code}' "\
-            "-u #{new_resource.username}:#{new_resource.password} "\
+            "-u '#{new_resource.username}':'#{new_resource.password}' "\
             "#{new_resource.instance}/crx/packmgr/service/.json/etc/packages"
 
   # Empty group fix


### PR DESCRIPTION
Whenever `admin`'s password contains special characters an error occurs. Here's an example: 

```
ERROR: Unable to retrive HTTP status from CQ instance.
Error description: Expected process to exit with [0], but received '1'
---- Begin output of curl -s -o /dev/null -w '%{http_code}' -u admin:pass_with(<{ http://localhost:4502/libs/granite/core/content/login.html ----
STDOUT:
STDERR: sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `curl -s -o /dev/null -w '%{http_code}' -u admin:pass_with(<{ http://localhost:4502/libs/granite/core/content/login.html'
```

All references to username/password have been put into single quotes to fix that. `cq_package` and `cq_osgi_config`  will be refactored to HWRP shortly, so this issue should be gone for good.