### PR TITLE
Instance specific healthchecks (start guard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,6 @@ installs Oracle's JDK7.
     <td>String</td>
     <td>Cookbook which is a source for conf file template</td>
   </tr>
-  <tr>
-    <td><tt>['cq']['healthcheck_resource']</tt></td>
-    <td>String</td>
-    <td>Resource that's queried during instance start to determine whether
-    CQ/AEM is fully operational</td>
-  </tr>
 </table>
 
 ## author.rb
@@ -308,6 +302,17 @@ All attributes in this file refer to CQ/AEM author instance (
     <td>String</td>
     <td>All other JVM patameters</td>
   </tr>
+  <tr>
+    <td><tt>['cq']['author']['healthcheck']['resource']</tt></td>
+    <td>String</td>
+    <td>Resource that's queried during instance start to determine whether
+    CQ/AEM is fully operational</td>
+  </tr>
+  <tr>
+    <td><tt>['cq']['author']['healthcheck']['response_code']</tt></td>
+    <td>String</td>
+    <td>Expected HTTP status code of healthcheck resource</td>
+  </tr>
 </table>
 
 ## publish.rb
@@ -434,6 +439,17 @@ All attributes in this file refer to CQ/AEM publish instance (
     <td><tt>['cq']['publish']['jvm']['extra_opts']</tt></td>
     <td>String</td>
     <td>All other JVM patameters</td>
+  </tr>
+  <tr>
+    <td><tt>['cq']['publish']['healthcheck']['resource']</tt></td>
+    <td>String</td>
+    <td>Resource that's queried during instance start to determine whether
+    CQ/AEM is fully operational</td>
+  </tr>
+  <tr>
+    <td><tt>['cq']['publish']['healthcheck']['response_code']</tt></td>
+    <td>String</td>
+    <td>Expected HTTP status code of healthcheck resource</td>
   </tr>
 </table>
 

--- a/attributes/author.rb
+++ b/attributes/author.rb
@@ -38,3 +38,6 @@ default['cq']['author']['jvm']['jmx_opts'] = ''
 default['cq']['author']['jvm']['debug_opts'] = ''
 default['cq']['author']['jvm']['crx_opts'] = ''
 default['cq']['author']['jvm']['extra_opts'] = ''
+default['cq']['author']['healthcheck']['resource'] =
+  '/libs/granite/core/content/login.html'
+default['cq']['author']['healthcheck']['response_code'] = '200'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,8 +38,6 @@ default['cq']['service']['restart_sleep'] = 5
 default['cq']['init_template_cookbook'] = 'cq'
 default['cq']['conf_template_cookbook'] = 'cq'
 
-default['cq']['healthcheck_resource'] = '/libs/granite/core/content/login.html'
-
 default['cq']['http_read_timeout'] = 300
 
 # Java attributes

--- a/attributes/publish.rb
+++ b/attributes/publish.rb
@@ -38,3 +38,6 @@ default['cq']['publish']['jvm']['jmx_opts'] = ''
 default['cq']['publish']['jvm']['debug_opts'] = ''
 default['cq']['publish']['jvm']['crx_opts'] = ''
 default['cq']['publish']['jvm']['extra_opts'] = ''
+default['cq']['publish']['healthcheck']['resource'] =
+  '/libs/granite/core/content/login.html'
+default['cq']['publish']['healthcheck']['response_code'] = '200'

--- a/definitions/cq_instance.rb
+++ b/definitions/cq_instance.rb
@@ -123,8 +123,8 @@ define :cq_instance,
   # Example:
   # * default run mode is set in this cookbook
   # * run mode is reconfigured on environment level
-  # * in one of recipes user would like to append additional run mode to the
-  #   one that's set on environment level
+  # * in a recipe user would like to append additional run mode to the one
+  #   that's set on environment level
   #
   # If node['cq'][local_id]['run_mode'] is set in a recipe that's included
   # after cq::author then nothing happens as template resource gets compiled

--- a/definitions/cq_instance.rb
+++ b/definitions/cq_instance.rb
@@ -177,7 +177,7 @@ define :cq_instance,
 
       # Pick valid resource to verify CQ instance full start
       uri = URI.parse("http://localhost:#{node['cq'][local_id]['port']}" +
-                      node['cq']['healthcheck_resource'])
+                      node['cq'][local_id]['healthcheck']['resource'])
 
       # Start timeout
       timeout = node['cq']['service']['start_timeout']
@@ -187,7 +187,7 @@ define :cq_instance,
 
       # Keep asking CQ instance for login page HTTP status code until it
       # returns 200 or specified time has elapsed
-      while response != '200'
+      while response != node['cq'][local_id]['healthcheck']['response_code']
         begin
           response = Net::HTTP.get_response(uri).code
         rescue => e

--- a/definitions/cq_instance.rb
+++ b/definitions/cq_instance.rb
@@ -116,6 +116,21 @@ define :cq_instance,
   end
 
   # Render CQ config file
+  #
+  # All template variables are lazy evaluated to cover scenarios when one of
+  # attributes i.e. run mode is set on multiple levels, including recipe.
+  #
+  # Example:
+  # * default run mode is set in this cookbook
+  # * run mode is reconfigured on environment level
+  # * in one of recipes user would like to append additional run mode to the
+  #   one that's set on environment level
+  #
+  # If node['cq'][local_id]['run_mode'] is set in a recipe that's included
+  # after cq::author then nothing happens as template resource gets compiled
+  # and all variables are already populated. With lazy evaluation user can do
+  # all required amendments in compile phase and these changes will be
+  # propagated correctly during converge phase.
   # ---------------------------------------------------------------------------
   template "#{instance_conf_dir}/cq#{cq_version('short_squeezed')}"\
            "-#{local_id}.conf" do


### PR DESCRIPTION
AEM/CQ start takes some time, so each instance has to be actively sampled to detect full start. Both healthcheck resource and HTTP response code should be configurable for each instance.