### PR TITLE
Decrypt should be recompiled every time JVM changes

### DIFF
--- a/libraries/_crypto_helper.rb
+++ b/libraries/_crypto_helper.rb
@@ -158,10 +158,6 @@ module Cq
       download_log_libs
       deploy_decryptor
 
-      Chef::Log.debug(
-        "Compiled version exists? #{File.exist?(decryptor_path + '.class')}"
-      )
-
       # Recompile Decrypt.java if needed
       compile_decryptor if !File.exist?(decryptor_path + '.class') ||
         jvm_version_changed?(decryptor_path)

--- a/libraries/_crypto_helper.rb
+++ b/libraries/_crypto_helper.rb
@@ -158,6 +158,10 @@ module Cq
       download_log_libs
       deploy_decryptor
 
+      Chef::Log.debug(
+        "Compiled version exists? #{File.exist?(decryptor_path + '.class')}"
+      )
+
       # Recompile Decrypt.java if needed
       compile_decryptor if !File.exist?(decryptor_path + '.class') ||
         jvm_version_changed?(decryptor_path)

--- a/libraries/_crypto_helper.rb
+++ b/libraries/_crypto_helper.rb
@@ -131,7 +131,7 @@ module Cq
     end
 
     def jvm_version_changed?(path)
-      current_jvm_version == compiled_with?(path)
+      current_jvm_version != compiled_with?(path)
     end
 
     # Makes sure the following elements are in place

--- a/libraries/_crypto_helper.rb
+++ b/libraries/_crypto_helper.rb
@@ -79,6 +79,7 @@ module Cq
     end
 
     def current_jvm_version
+      Chef::Log.debug("Current JVM version: #{node['java']['jdk_version']}")
       node['java']['jdk_version']
     end
 

--- a/libraries/_crypto_helper.rb
+++ b/libraries/_crypto_helper.rb
@@ -118,7 +118,7 @@ module Cq
       major = cmd.stdout[/^\s+major\sversion:\s(?<version>.+)/, 'version']
       minor = cmd.stdout[/^\s+minor\sversion:\s(?<version>.+)/, 'version']
 
-      java_version = jvm_version_mapper(major + '.'+ minor)
+      java_version = jvm_version_mapper(major + '.' + minor)
       Chef::Log.debug("#{path} was compiled with Java #{java_version}")
 
       java_version
@@ -155,7 +155,7 @@ module Cq
 
       # Recompile Decrypt.java if needed
       compile_decryptor if !File.exist?(decryptor_path + '.class') ||
-        jvm_version_changed?(decryptor_path)
+                           jvm_version_changed?(decryptor_path)
     end
 
     def crypto_dir_structure

--- a/libraries/_crypto_helper.rb
+++ b/libraries/_crypto_helper.rb
@@ -78,11 +78,6 @@ module Cq
       Chef::Application.fatal!("Can't extract content out of JAR file: #{e}")
     end
 
-    def current_jvm_version
-      Chef::Log.debug("Current JVM version: #{node['java']['jdk_version']}")
-      node['java']['jdk_version']
-    end
-
     # Source:
     # * http://stackoverflow.com/a/1096159/6802186
     # * http://stackoverflow.com/a/27123/6802186
@@ -132,7 +127,7 @@ module Cq
     end
 
     def jvm_version_changed?(path)
-      current_jvm_version != compiled_with?(path)
+      node['java']['jdk_version'] != compiled_with?(path)
     end
 
     # Makes sure the following elements are in place


### PR DESCRIPTION
Turned out there's an edge case related to JVM updates and/or downgrades.

Case my colleague run into:
* AEM was initially deployed on JDK8
* JDK was downgraded to JDK7
* `encrypted_properties` stopped working (code compiled on 8th version won't run on 7th)

This PR addresses this case.