### PR TITLE
Password change on AEM 6.2 (just publish) does not work

### DIFF
--- a/libraries/_http_helper.rb
+++ b/libraries/_http_helper.rb
@@ -46,7 +46,7 @@ module Cq
       http = Net::HTTP.new(uri.host, uri.port)
       http.read_timeout = node['cq']['http_read_timeout']
       http_req = Net::HTTP::Get.new(uri.request_uri)
-      http_req.basic_auth(user, password)
+      http_req.basic_auth(user, password) if !user.nil? && !password.nil?
 
       begin
         http.request(http_req)
@@ -61,7 +61,7 @@ module Cq
       http = Net::HTTP.new(uri.host, uri.port)
       http.read_timeout = node['cq']['http_read_timeout']
       http_req = Net::HTTP::Post.new(uri.request_uri)
-      http_req.basic_auth(user, password)
+      http_req.basic_auth(user, password) if !user.nil? && !password.nil?
       http_req.set_form_data(payload)
 
       begin
@@ -78,7 +78,7 @@ module Cq
       http = Net::HTTP.new(uri.host, uri.port)
       http.read_timeout = node['cq']['http_read_timeout']
       http_req = Net::HTTP::Post::Multipart.new(uri.request_uri, payload)
-      http_req.basic_auth(user, password)
+      http_req.basic_auth(user, password) if !user.nil? && !password.nil?
 
       begin
         http.request(http_req)

--- a/libraries/provider_cq_user.rb
+++ b/libraries/provider_cq_user.rb
@@ -113,9 +113,9 @@ class Chef
 
         Chef::Application.fatal!(
           'Unable to determine valid admin credentials! The following '\
-          'user/pass pairs were checked: \n'\
-          '* admin / <password>\n'\
-          '* admin / <old_password>\n'\
+          "user/pass pairs were checked: \n"\
+          "* admin / <password>\n"\
+          "* admin / <old_password>\n"\
           '* admin / admin'
         )
       end

--- a/libraries/provider_cq_user.rb
+++ b/libraries/provider_cq_user.rb
@@ -113,7 +113,7 @@ class Chef
 
         Chef::Application.fatal!(
           'Unable to determine valid admin credentials! The following '\
-          "user/pass pairs were checked: \n"\
+          "user/pass pairs were verified: \n"\
           "* admin / <password>\n"\
           "* admin / <old_password>\n"\
           '* admin / admin'

--- a/libraries/provider_cq_user.rb
+++ b/libraries/provider_cq_user.rb
@@ -104,6 +104,10 @@ class Chef
             payload
           )
 
+          Chef::Log.debug(
+            "#{req_path} requested as admin / #{p} returned #{http_resp.code}"
+          )
+
           return p if http_resp.code == '200'
         end
 

--- a/libraries/provider_cq_user.rb
+++ b/libraries/provider_cq_user.rb
@@ -85,10 +85,24 @@ class Chef
       end
 
       def current_admin_password
-        req_path = '/libs/granite/core/content/login.html'
+        req_path = '/crx/de/j_security_check'
 
         [new_resource.password, new_resource.old_password, 'admin'].each do |p|
-          http_resp = http_get(new_resource.instance, req_path, 'admin', p)
+          payload = {
+            'j_username' => 'admin',
+            'j_password' => p,
+            'j_workspace' => 'crx.default',
+            'j_validate' => 'true',
+            '_charset_' => 'utf-8'
+          }
+
+          http_resp = http_post(
+            new_resource.instance,
+            req_path,
+            nil,
+            nil,
+            payload
+          )
 
           return p if http_resp.code == '200'
         end


### PR DESCRIPTION
It turned out that on bare AEM 6.2 publish instance (but not on author) HTTP request to `/libs/granite/core/content/login.html` with `Authorization` header always ends with 200 (despite of the fact base64 out of `username:password` is invalid).

It's been decided to update HTTP endpoint `admin` user credentials are validated against. `/crx/de/j_security_check` seems to be a much better option. 