### PR TITLE
OSGi bundle operations fails when requested without cookie

### DIFF
--- a/libraries/_http_helper.rb
+++ b/libraries/_http_helper.rb
@@ -59,7 +59,9 @@ module Cq
       end
     end
 
-    def http_post(addr, path, user, password, payload, query = nil)
+    def http_post(
+      addr, path, user, password, payload, query = nil, headers = {}
+    )
       uri = parse_uri(addr + path, query)
 
       http = Net::HTTP.new(uri.host, uri.port)
@@ -68,6 +70,10 @@ module Cq
       http_req.basic_auth(user, password) if !user.nil? && !password.nil?
       http_req.set_form_data(payload)
 
+      headers.each do |name, value|
+        http_req[name] = value
+      end
+
       begin
         http.request(http_req)
       rescue => e
@@ -75,7 +81,9 @@ module Cq
       end
     end
 
-    def http_multipart_post(addr, path, user, password, payload, query = nil)
+    def http_multipart_post(
+      addr, path, user, password, payload, query = nil, headers = {}
+    )
       require 'net/http/post/multipart'
 
       uri = parse_uri(addr + path, query)
@@ -83,6 +91,10 @@ module Cq
       http.read_timeout = node['cq']['http_read_timeout']
       http_req = Net::HTTP::Post::Multipart.new(uri.request_uri, payload)
       http_req.basic_auth(user, password) if !user.nil? && !password.nil?
+
+      headers.each do |name, value|
+        http_req[name] = value
+      end
 
       begin
         http.request(http_req)

--- a/libraries/_http_helper.rb
+++ b/libraries/_http_helper.rb
@@ -40,13 +40,17 @@ module Cq
       Chef::Application.fatal!("Unable to parse #{str} as JSON: #{e}")
     end
 
-    def http_get(addr, path, user, password, query = nil)
+    def http_get(addr, path, user, password, query = nil, headers = {})
       uri = parse_uri(addr + path, query)
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.read_timeout = node['cq']['http_read_timeout']
       http_req = Net::HTTP::Get.new(uri.request_uri)
       http_req.basic_auth(user, password) if !user.nil? && !password.nil?
+
+      headers.each do |name, value|
+        http_req[name] = value
+      end
 
       begin
         http.request(http_req)

--- a/libraries/_osgi_bundle_helper.rb
+++ b/libraries/_osgi_bundle_helper.rb
@@ -22,7 +22,14 @@ module Cq
     include Cq::HttpHelper
 
     def raw_bundle_list(addr, user, password)
-      http_get(addr, '/system/console/bundles/.json', user, password)
+      http_get(
+        addr,
+        '/system/console/bundles/.json',
+        user,
+        password,
+        nil,
+        'Cookie' => 'felix-webconsole-locale=en'
+      )
     end
 
     def bundle_list(addr, user, password)

--- a/libraries/_osgi_bundle_helper.rb
+++ b/libraries/_osgi_bundle_helper.rb
@@ -45,12 +45,19 @@ module Cq
 
     # Executes defined operation on given bundle ID
     def bundle_op(addr, user, password, id, op)
-      req_path = "/system/console/bundles/#{id}"
       payload = {
         'action' => op
       }
 
-      http_post(addr, req_path, user, password, payload)
+      http_post(
+        addr,
+        "/system/console/bundles/#{id}",
+        user,
+        password,
+        payload,
+        nil,
+        'Cookie' => 'felix-webconsole-locale=en'
+      )
     end
 
     # stateRaw:


### PR DESCRIPTION
Just encountered totally weird case on AEM 6.2 (related to Oak 1.4.8 installation). Here's how it behaves:

```
$ curl localhost:4502/system/console/bundles/.json -u admin:admin -s
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 500 </title>
</head>
<body>
<h2>HTTP ERROR: 500</h2>
<p>Problem accessing /system/console/bundles/.json. Reason:
<pre>    java.lang.NullPointerException</pre></p>
<hr /><i><small>Powered by Jetty://</small></i>
</body>
</html>
 
$ curl localhost:4502/system/console/bundles/.json -u admin:admin -s -H 'Cookie:felix-webconsole-locale=en'
<proper JSON>
```

This PR addresses this problem.