### PR TITLE
javap execution fails on some platforms

### DIFF
--- a/libraries/_crypto_helper.rb
+++ b/libraries/_crypto_helper.rb
@@ -68,11 +68,12 @@ module Cq
 
     def extract_jar(jar, filter, dst)
       cmd_str = "unzip -o -b -j #{jar} \"#{filter}\" -d #{dst}"
+      Chef::Log.debug("Unzip command: #{cmd_str}")
+
       cmd = Mixlib::ShellOut.new(cmd_str)
       cmd.run_command
       cmd.error!
 
-      Chef::Log.debug("Unzip command: #{cmd_str}")
       Chef::Log.debug("JAR file successfully extracted:\n #{cmd.stdout}")
     rescue => e
       Chef::Application.fatal!("Can't extract content out of JAR file: #{e}")
@@ -110,6 +111,8 @@ module Cq
     # Returns version of Java given file in crypto_root_dir was compiled with
     def compiled_with?(filename)
       cmd_str = "javap -cp '#{crypto_classpath}' -verbose #{filename}"
+      Chef::Log.debug("javap command: #{cmd_str}")
+
       cmd = Mixlib::ShellOut.new(cmd_str, :cwd => crypto_root_dir)
       cmd.run_command
       cmd.error!
@@ -260,11 +263,12 @@ module Cq
 
     def compile_decryptor
       cmd_str = "javac -cp '#{crypto_classpath}' Decrypt.java"
+      Chef::Log.debug("Compilation command: #{cmd_str}")
+
       cmd = Mixlib::ShellOut.new(cmd_str, :cwd => crypto_root_dir)
       cmd.run_command
       cmd.error!
 
-      Chef::Log.debug("Compilation command: #{cmd_str}")
       Chef::Log.debug('Decryptor successfully compiled')
     rescue => e
       Chef::Application.fatal!("Compilation error: #{e}")
@@ -324,7 +328,6 @@ module Cq
 
     def decrypt(key, str)
       cmd_str = "java -cp '#{crypto_classpath}' Decrypt '#{key}' '#{str}'"
-
       Chef::Log.debug("Decrypt command: #{cmd_str}")
 
       # Decrypt code needs high entropy level to get things done in an


### PR DESCRIPTION
Under certain circumstances (details unknown) `javap` command that's, used to determine which Java version was used to compile decryptor helper, fails with the following message:

```
[root@xyz ~]# javap -verbose /var/chef/cache/crypto/Decrypt; echo $?
Error: class not found: /var/chef/cache/crypto/Decrypt
1
```

Platform/Chef details:
* OS: CentOS Linux release 7.3.1611 (Core)
* chef-client: 12.5.1 & 12.17.44
* `java` cookbook: 1.31.0

Since that's a blocker it's been decided to use the following workaround:
* exec `javap` directly from directory in which given file was placed
* pass classpath to `javap` to make sure nothing's missing