### PR TITLE
Updated java cookbook version to fix nosuchmethod ‘kernel’ exception

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,8 @@ description      'Installs/Configures cq'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.0'
 
-depends          'java'
-depends          'ulimit'
+depends          'java',            '~> 1.50.0'
+depends          'ulimit',          '~> 0.3.3'
 depends          'cq-unix-toolkit', '~> 1.2.0'
 
 source_url       'https://github.com/jwadolowski/cookbook-cq'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jakub.wadolowski@cognifide.com'
 license          'Apache 2.0'
 description      'Installs/Configures cq'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '1.0.1'
 
 depends          'java',            '~> 1.50.0'
 depends          'ulimit',          '~> 0.3.3'

--- a/recipes/commons.rb
+++ b/recipes/commons.rb
@@ -43,7 +43,7 @@ end
 # Create user
 user node['cq']['user'] do
   uid node['cq']['user_uid'] if node['cq']['user_uid']
-  supports :manage_home => true
+  manage_home true
   system true
   comment node['cq']['user_comment']
   group node['cq']['group']


### PR DESCRIPTION
Latest chef does not support kernel['XXX'] but should be node['kernel'] to fix this java cookbook version needs to be upgraded