### PR TITLE
Fallback to DELETE method when deleting nodes via Sling API

### DIFF
--- a/libraries/_http_helper.rb
+++ b/libraries/_http_helper.rb
@@ -55,6 +55,21 @@ module Cq
       end
     end
 
+    def http_delete(addr, path, user, password, query = nil)
+      uri = parse_uri(addr + path, query)
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.read_timeout = node['cq']['http_read_timeout']
+      http_req = Net::HTTP::Delete.new(uri.request_uri)
+      http_req.basic_auth(user, password) if !user.nil? && !password.nil?
+
+      begin
+        http.request(http_req)
+      rescue => e
+        Chef::Log.error("Unable to send DELETE request: #{e}")
+      end
+    end
+
     def http_post(addr, path, user, password, payload, query = nil)
       uri = parse_uri(addr + path, query)
 

--- a/libraries/provider_cq_user.rb
+++ b/libraries/provider_cq_user.rb
@@ -166,7 +166,7 @@ class Chef
 
       def crx_query(user, pass)
         max_attempts ||= 3
-        attempt ||= 0
+        attempt ||= 1
 
         req_path ||= '/bin/querybuilder.json'
         query_params ||= {


### PR DESCRIPTION
JCR nodes can be deleted using either `POST` or `DELETE` HTTP methods. `POST` is recommended according to Sling API documentation, but there are rare use cases where `DELETE` has to be used. New implementation assumes 3 `POST` attempts followed by 3 `DELETE` attempts (automatic fallback) before raising an error.