### PR TITLE
cq_start_guard resource

### DIFF
--- a/attributes/author.rb
+++ b/attributes/author.rb
@@ -41,3 +41,6 @@ default['cq']['author']['jvm']['extra_opts'] = ''
 default['cq']['author']['healthcheck']['resource'] =
   '/libs/granite/core/content/login.html'
 default['cq']['author']['healthcheck']['response_code'] = '200'
+default['cq']['author']['healthcheck']['response_body'] =
+  '<!-- QUICKSTART_HOMEPAGE - (string used for readyness detection, do not '\
+  'remove) -->'

--- a/attributes/author.rb
+++ b/attributes/author.rb
@@ -42,5 +42,4 @@ default['cq']['author']['healthcheck']['resource'] =
   '/libs/granite/core/content/login.html'
 default['cq']['author']['healthcheck']['response_code'] = '200'
 default['cq']['author']['healthcheck']['response_body'] =
-  '<!-- QUICKSTART_HOMEPAGE - (string used for readyness detection, do not '\
-  'remove) -->'
+  '<!-- QUICKSTART_HOMEPAGE - (string used for readyness detection, do not remove) -->'

--- a/attributes/publish.rb
+++ b/attributes/publish.rb
@@ -41,3 +41,6 @@ default['cq']['publish']['jvm']['extra_opts'] = ''
 default['cq']['publish']['healthcheck']['resource'] =
   '/libs/granite/core/content/login.html'
 default['cq']['publish']['healthcheck']['response_code'] = '200'
+default['cq']['publish']['healthcheck']['response_body'] =
+  '<!-- QUICKSTART_HOMEPAGE - (string used for readyness detection, do not '\
+  'remove) -->'

--- a/attributes/publish.rb
+++ b/attributes/publish.rb
@@ -42,5 +42,4 @@ default['cq']['publish']['healthcheck']['resource'] =
   '/libs/granite/core/content/login.html'
 default['cq']['publish']['healthcheck']['response_code'] = '200'
 default['cq']['publish']['healthcheck']['response_body'] =
-  '<!-- QUICKSTART_HOMEPAGE - (string used for readyness detection, do not '\
-  'remove) -->'
+  '<!-- QUICKSTART_HOMEPAGE - (string used for readyness detection, do not remove) -->'

--- a/definitions/cq_instance.rb
+++ b/definitions/cq_instance.rb
@@ -282,58 +282,18 @@ define :cq_instance, id: nil do
     supports status: true, restart: true
     action :start
 
-    notifies :run, "ruby_block[cq-#{local_id}-start-guard]", :immediately
+    notifies :run, "cq_start_guard[#{daemon_name}]", :immediately
   end
 
   # ---------------------------------------------------------------------------
   # Wait until CQ is fully up and running
   # ---------------------------------------------------------------------------
-  ruby_block "cq-#{local_id}-start-guard" do # ~FC014
-    block do
-      require 'net/http'
-      require 'uri'
-
-      # Pick valid resource to verify CQ instance full start
-      uri = URI.parse(
-        "http://localhost:#{node['cq'][local_id]['port']}" +
-        node['cq'][local_id]['healthcheck']['resource']
-      )
-
-      # Start timeout
-      start_timeout = node['cq']['service']['start_timeout']
-
-      # Save current net read timeout value
-      current_http_timeout = node['cq']['http_read_timeout']
-
-      response = '-1'
-      start_time = Time.now
-
-      # Keep asking CQ instance for login page HTTP status code until it
-      # returns 200 or specified time has elapsed
-      while response != node['cq'][local_id]['healthcheck']['response_code']
-        begin
-          # Reduce net read time value to speed up start guard procedure
-          node.default['cq']['http_read_timeout'] = 5
-
-          response = Net::HTTP.get_response(uri).code
-          Chef::Log.debug("HTTP response: #{response}")
-        rescue => e
-          Chef::Log.debug(
-            "Error occurred while trying to send GET #{uri} request: #{e}"
-          )
-        ensure
-          # Restore original timeout
-          node.default['cq']['http_read_timeout'] = current_http_timeout
-        end
-        sleep(5)
-        time_diff = Time.now - start_time
-        Chef::Log.debug("Time elapsed since process start: #{time_diff}")
-        abort "Aborting since #{daemon_name} start took more than "\
-          "#{start_timeout / 60} minutes " if time_diff > start_timeout
-      end
-
-      Chef::Log.info("CQ start time: #{time_diff} seconds")
-    end
+  cq_start_guard daemon_name do
+    instance "http://localhost:#{node['cq'][local_id]['port']}"
+    path node['cq'][local_id]['healthcheck']['resource']
+    expected_code node['cq'][local_id]['healthcheck']['response_code']
+    expected_body node['cq'][local_id]['healthcheck']['response_body']
+    timeout node['cq']['service']['start_timeout']
 
     action :nothing
   end

--- a/resources/cq_start_guard.rb
+++ b/resources/cq_start_guard.rb
@@ -1,0 +1,86 @@
+#
+# Cookbook Name:: cq
+# Resource:: cq_start_guard
+#
+# Copyright (C) 2018 Jakub Wadolowski
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include Cq::HttpHelper
+
+resource_name :cq_start_guard
+
+property :name, String, name_property: true
+property :instance, String, default: 'http://localhost:4502'
+property :path, String, default: '/libs/granite/core/content/login.html'
+property :expected_code, String, default: '200'
+property :expected_body, String, default: '<!-- QUICKSTART_HOMEPAGE - (string used for readyness detection, do not remove) -->'
+property :timeout, Integer, default: 1800
+property :http_timeout, Integer, default: 5
+property :interval, Integer, default: 5
+
+default_action :nothing
+
+action_class do
+  def expected_response?(http_response)
+    if new_resource.expected_body
+      http_response.code == new_resource.expected_code &&
+        http_response.body.include?(new_resource.expected_body)
+    else
+      http_response.code == new_resource.expected_code
+    end
+  end
+
+  def elapsed_time(start_time)
+    Time.now - start_time
+  end
+end
+
+action :nothing
+
+action :run do
+  begin
+    start_time ||= Time.now
+
+    # HTTP NetReadTimeout changes:
+    # * save its current value, so it can be restored at the very end
+    # * reduce it to speed the whole process up
+    current_http_timeout ||= node['cq']['http_read_timeout']
+    node.default['cq']['http_read_timeout'] = new_resource.http_timeout
+
+    resp = http_get(new_resource.instance, new_resource.path, nil, nil)
+
+    unless resp.is_a?(Net::HTTPResponse)
+      raise(Net::HTTPUnknownResponse, 'Unknown HTTP response')
+    end
+
+    unless expected_response?(resp, input_params)
+      raise(Net::HTTPBadResponse, 'Wrong HTTP response')
+    end
+
+    Chef::Log.info("CQ start time: #{elapsed_time(start_time)} seconds")
+  rescue
+    if elapsed_time(start_time) < new_resource.timeout
+      sleep(new_resource.interval)
+      retry
+    else
+      Chef::Application.fatal!(
+        "Chef run aborted, as CQ start took more than #{new_resource.timeout}s"
+      )
+    end
+  ensure
+    # Restore original HTTP timeout
+    node.default['cq']['http_read_timeout'] = current_http_timeout
+  end
+end

--- a/resources/cq_start_guard.rb
+++ b/resources/cq_start_guard.rb
@@ -47,8 +47,6 @@ action_class do
   end
 end
 
-action :nothing
-
 action :run do
   begin
     start_time ||= Time.now
@@ -65,7 +63,7 @@ action :run do
       raise(Net::HTTPUnknownResponse, 'Unknown HTTP response')
     end
 
-    unless expected_response?(resp, input_params)
+    unless expected_response?(resp)
       raise(Net::HTTPBadResponse, 'Wrong HTTP response')
     end
 


### PR DESCRIPTION
`cq_start_guard` resource was introduce to simplify waiting for full start of AEM instance. Replaces #53 

Such resource can be really handy when AEM itself was installed by someone else, but you'd like to manage it via Chef resource and restart it upon certain action (i.e. after package installation). 