### PR TITLE
cq_clientlib_cache actions wrapped into ruby_block 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.2.8 (2019-10-31)
+
+* `cq_clientlib_cache` actions wrapped into `ruby_block` to mark resource execution during converge phase
+
 # v1.2.7 (2019-09-05)
 
 * All crypto JAR regexes updated to keep things consistent

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jakub.wadolowski@cognifide.com'
 license          'Apache-2.0'
 description      'Installs and configures Adobe AEM (formerly CQ)'
 long_description 'Installs and configures Adobe AEM (formerly CQ)'
-version          '1.2.7'
+version          '1.2.8'
 
 depends          'java'
 depends          'ulimit'

--- a/resources/cq_clientlib_cache.rb
+++ b/resources/cq_clientlib_cache.rb
@@ -81,9 +81,21 @@ action_class do
 end
 
 action :invalidate do
-  cache_action(:invalidate)
+  ruby_block 'Invalidate clientlib cache' do
+    block do
+      cache_action(:invalidate)
+    end
+
+    action :run
+  end
 end
 
 action :rebuild do
-  cache_action(:rebuild)
+  ruby_block 'Rebuild clientlib cache' do
+    block do
+      cache_action(:rebuild)
+    end
+
+    action :run
+  end
 end


### PR DESCRIPTION
Required to mark resource execution during converge phase (green colour when resource was executed).