### PR TITLE
Allow setting password for user without password

### DIFF
--- a/libraries/provider_cq_user.rb
+++ b/libraries/provider_cq_user.rb
@@ -291,9 +291,13 @@ class Chef
       # All credits goes to Tomasz Rekawek
       # https://gist.github.com/trekawek/9955166
       def password_update?(new_pass)
-        return false if current_resource.info['rep:password'].end_with?(
-          hash_generator(new_pass)
-        )
+        if current_resource.info['rep:password'] == nil
+          return true
+        else
+          return false if current_resource.info['rep:password'].end_with?(
+            hash_generator(new_pass)
+          )
+        end
         true
       end
 


### PR DESCRIPTION
If user does not have rep:password code fails with:
Caused by NoMethodError: undefined method `match' for nil:NilClass
/var/chef/cache/cookbooks/cq/libraries/provider_cq_user.rb:246:in `hash_decoder'
/var/chef/cache/cookbooks/cq/libraries/provider_cq_user.rb:268:in `hash_generator'
/var/chef/cache/cookbooks/cq/libraries/provider_cq_user.rb:295:in `password_update?'
/var/chef/cache/cookbooks/cq/libraries/provider_cq_user.rb:70:in `modify_user'

The problem is that ruby evaluates hash_generator(new_pass) before checking if end_with? can be called on nil.