### PR TITLE
Prevent runtime failures after OSGi component state change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.3.1 (2021-07-29)
+
+* Prevent runtime failures after OSGi component state change (invalid response from AEM)
+
 # v1.3.0 (2020-05-13)
 
 * [#75](https://github.com/jwadolowski/cookbook-cq/pull/78) RHEL/CentOS 8 Support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.3.1 (2021-07-29)
 
 * Prevent runtime failures after OSGi component state change (invalid response from AEM)
+* `Rakefile` changes backported from `master`
 
 # v1.3.0 (2020-05-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.3.1 (2021-07-29)
+# v1.3.1 (2021-08-03)
 
 * Prevent runtime failures after OSGi component state change (invalid response from AEM)
 * `Rakefile` changes backported from `master`

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ end
 # -----------------------------------------------------------------------------
 namespace 'git' do
   desc 'Create new Git tag'
-  task :tag do
+  task tag: ['lint'] do
     sh "git tag -a v#{cookbook_version} -m \"v#{cookbook_version} release\""
   end
 
@@ -48,11 +48,8 @@ end
 namespace 'style' do
   require 'cookstyle'
   require 'rubocop/rake_task'
-  require 'foodcritic'
 
   RuboCop::RakeTask.new(:cookstyle)
-
-  FoodCritic::Rake::LintTask.new(:foodcritic)
 end
 
 # -----------------------------------------------------------------------------
@@ -70,12 +67,15 @@ end
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
-desc 'Run linters (Foodcritic & Cookstyle)'
-task lint: ['style:foodcritic', 'style:cookstyle']
+desc 'Run linters'
+task lint: ['style:cookstyle']
 
 desc 'Release new cookbook version'
 task release: [
   'berkshelf:update', 'git:release', 'berkshelf:upload', 'stove:publish'
 ]
+
+desc 'Upload released cookbook to Chef Server'
+task upload: ['berkshelf:update', 'berkshelf:upload']
 
 task default: :release

--- a/libraries/_osgi_component_helper.rb
+++ b/libraries/_osgi_component_helper.rb
@@ -62,12 +62,12 @@ module Cq
 
       rescue JSON::ParserError
         {
-          "id": "-1",
-          "name": pid,
-          "state": "undefined",
-          "stateRaw": -1,
-          "pid": pid,
-          "props": []
+          "id" => "-1",
+          "name" => pid,
+          "state" => "undefined",
+          "stateRaw" => -1,
+          "pid" => pid,
+          "props" => []
         }
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jakub.wadolowski@cognifide.com'
 license          'Apache-2.0'
 description      'Installs and configures Adobe AEM (formerly CQ)'
 long_description 'Installs and configures Adobe AEM (formerly CQ)'
-version          '1.3.0'
+version          '1.3.1'
 
 depends          'java'
 depends          'ulimit'


### PR DESCRIPTION
Sample flow:

```
cq_package 'my-package' do
  ...

  action :deploy
end

cq_osgi_component 'Author: WorkflowLauncherImpl (disable)' do
  pid 'com.adobe.granite.workflow.core.launcher.WorkflowLauncherImpl'
  ...

  action :disable
end
```

Here's what happens under the hood:
* the package gets installed, which may or may not impact OSGi bundle/component state (`same_state_barrier`, `max_attempts`, etc properties could be set incorrectly)
* the component is disabled (`POST` request was handled by AEM successfully)
* once that's done `cq_osgi_component` resource checks in a loop if desired state was reached - in other words `/system/console/components/#{pid}.json` is requested several times to make sure it was disabled successfully)   
* `cq_osgi_component` expects a valid JSON response, but during the state change operation you may encounter 4xx/5xx response with the following body instead
```
<html>
    <head>
        <meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
        <title>Error 404 </title>
    </head>
    <body>
        <h2>HTTP ERROR: 404</h2>
        <p>Problem accessing /system/console/components/[PID].json Reason:
        <pre>    Not Found</pre></p>
        <hr /><i><small>Powered by Jetty://</small></i>
    </body>
</html>
```

This PR fixes the problem and prevents runtime (converge phase) failures.

---

**EDIT**

It turned out that on AEM 6.2 `/system/console/components/#{pid}.json` permanently returns 404 when component got disabled. On 6.5 aforementioned URL is still accessible and returns valid JSON.